### PR TITLE
fix: edit product page wrong title

### DIFF
--- a/src/main/resources/templates/EditProduct.html
+++ b/src/main/resources/templates/EditProduct.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
   <head>
     <meta charset="UTF-8">
-    <title>Create New Product</title>
+    <title>Edit Product</title>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERd`knLPMO" crossorigin="anonymous">
   </head>
   <body>


### PR DESCRIPTION
Change from `Create New Product` to `Edit Product`.